### PR TITLE
Add "push" mode

### DIFF
--- a/transfer_manifest_old2json.py
+++ b/transfer_manifest_old2json.py
@@ -12,10 +12,12 @@ import os
 def verify_request(name, size):
     return f"VERIFY_REQUEST {json.dumps({'name': name, 'size': int(size)})}\n"
 
+
 # TRANSFER_REQUEST Arlington_2020/712W/20200628RGB/DJI_0320.JPG 7594853
 # TRANSFER_REQUEST {"name": "Arlington_2020/Field 1 GXE/20200628NDRE/IMG_00001.jpg", "size": 2157739}
 def transfer_request(name, size):
     return f"TRANSFER_REQUEST {json.dumps({'name': name, 'size': int(size)})}\n"
+
 
 # TRANSFER_VERIFIED Madison_M1500_2020/20200613RGB/DJI_0070.JPG a28d9dee507a9fea54f4a55a495b013c050e3928 7587670 1593181879
 # TRANSFER_VERIFIED {"timestamp": 1593181879, "name": "Arlington_2020/Field 712/20200621_16-13-23/NDVI/IMG_00389.jpg", "digest": "1f2cec0df3017e944e93fa56104dbfc4096a76ea", "size": 2474228}
@@ -24,57 +26,63 @@ def transfer_verified(name, digest, size, timestamp):
 
 
 CONVERT = {
-    'VERIFY_REQUEST': verify_request,
-    'TRANSFER_REQUEST': transfer_request,
-    'TRANSFER_VERIFIED': transfer_verified,
+    "VERIFY_REQUEST": verify_request,
+    "TRANSFER_REQUEST": transfer_request,
+    "TRANSFER_VERIFIED": transfer_verified,
 }
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("old", type=Path, help="Path to old-style transfer_manifest.txt")
+    parser.add_argument(
+        "old", type=Path, help="Path to old-style transfer_manifest.txt"
+    )
     args = parser.parse_args()
-    
+
     old = args.old.resolve()
-    bak = old.with_suffix('.bak')
-    tmp = old.with_suffix('.tmp')
+    bak = old.with_suffix(".bak")
+    tmp = old.with_suffix(".tmp")
     shutil.copy(old, bak)
 
     skipped_lines = 0
     try:
-        with open(tmp, mode='w') as f:
+        with open(tmp, mode="w") as f:
             for i, line in enumerate(old.open()):
                 tokens = line.rstrip().split()
                 if len(tokens) < 1:
                     print(f"Bad line {i+1}, skipping: {line.rstrip()}")
                     skipped_lines += 1
-                elif tokens[0] in ['SYNC_REQUEST'] and len(tokens) == 8:
+                elif tokens[0] in ["SYNC_REQUEST"] and len(tokens) == 8:
                     f.write(line)
-                elif tokens[0] in ['SYNC_DONE'] and len(tokens) == 2:
+                elif tokens[0] in ["SYNC_DONE"] and len(tokens) == 2:
                     f.write(line)
-                elif tokens[0] in ['TRANSFER_REQUEST', 'VERIFY_REQUEST']:
-                    if tokens[1].startswith('{') and tokens[-1].endswith('}'):
+                elif tokens[0] in ["TRANSFER_REQUEST", "VERIFY_REQUEST"]:
+                    if tokens[1].startswith("{") and tokens[-1].endswith("}"):
                         try:
                             json.loads(" ".join(tokens[1:]))
                             f.write(line)
                         except json.decoder.JSONDecodeError:
                             print(f"Bad line {i+1}, skipping: {line.rstrip()}")
                             skipped_lines += 1
-                    elif len(tokens) == 3 and not ('{' in ''.join(tokens) or '}' in ''.join(tokens)):
+                    elif len(tokens) == 3 and not (
+                        "{" in "".join(tokens) or "}" in "".join(tokens)
+                    ):
                         newline = CONVERT[tokens[0]](*tokens[1:])
                         f.write(newline)
                     else:
                         print(f"Bad line {i+1}, skipping: {line.rstrip()}")
                         skipped_lines += 1
-                elif tokens[0] in ['TRANSFER_VERIFIED']:
-                    if tokens[1].startswith('{') and tokens[-1].endswith('}'):
+                elif tokens[0] in ["TRANSFER_VERIFIED"]:
+                    if tokens[1].startswith("{") and tokens[-1].endswith("}"):
                         try:
                             json.loads(" ".join(tokens[1:]))
                             f.write(line)
                         except json.decoder.JSONDecodeError:
                             print(f"Bad line {i+1}, skipping: {line.rstrip()}")
                             skipped_lines += 1
-                    elif len(tokens) == 5 and not ('{' in ''.join(tokens) or '}' in ''.join(tokens)):
+                    elif len(tokens) == 5 and not (
+                        "{" in "".join(tokens) or "}" in "".join(tokens)
+                    ):
                         newline = CONVERT[tokens[0]](*tokens[1:])
                         f.write(newline)
                     else:

--- a/xfer.py
+++ b/xfer.py
@@ -20,8 +20,7 @@ import time
 import htcondor
 
 
-PARENT_DAG = \
-"""
+PARENT_DAG = """
 # Gather the remote file listing.
 JOB CalculateWork calc_work.sub DIR calc_work
 
@@ -35,8 +34,7 @@ SCRIPT POST DoXfers {exec_py} analyze {transfer_manifest}
 PARENT CalculateWork CHILD DoXfers
 """
 
-CALC_WORK_JOB = \
-"""
+CALC_WORK_JOB = """
 universe = vanilla
 executable = {exec_py}
 output = calc_work.out
@@ -55,8 +53,7 @@ request_disk = 1GB
 queue
 """
 
-XFER_FILE_JOB = \
-"""
+XFER_FILE_JOB = """
 universe = vanilla
 executable = {xfer_py}
 output = $(src_file_noslash).out
@@ -75,8 +72,7 @@ request_disk = 1GB
 queue
 """
 
-XFER_FILE_N_JOB = \
-"""
+XFER_FILE_N_JOB = """
 universe = vanilla
 executable = {xfer_py}
 output = $(name).out
@@ -95,8 +91,7 @@ request_disk = 1GB
 queue
 """
 
-VERIFY_FILE_JOB = \
-"""
+VERIFY_FILE_JOB = """
 universe = vanilla
 executable = {xfer_py}
 output = $(src_file_noslash).out
@@ -115,15 +110,13 @@ request_disk = 1GB
 queue
 """
 
-DO_WORK_DAG_HEADER = \
-"""
+DO_WORK_DAG_HEADER = """
 CATEGORY ALL_NODES TRANSFER_JOBS
 {}
 
 """
 
-DO_WORK_DAG_XFER_SNIPPET = \
-"""
+DO_WORK_DAG_XFER_SNIPPET = """
 JOB xfer_{name} xfer_file.sub DIR calc_work
 VARS xfer_{name} src_file_noslash="{src_file_noslash}"
 VARS xfer_{name} src_file="{src_file}"
@@ -132,8 +125,7 @@ SCRIPT POST xfer_{name} {xfer_py} verify --json=xfer_commands_{fileidx}.json --f
 
 """
 
-DO_WORK_DAG_VERIFY_SNIPPET = \
-"""
+DO_WORK_DAG_VERIFY_SNIPPET = """
 JOB verify_{name} verify_file.sub DIR calc_work
 VARS verify_{name} src_file_noslash="{src_file_noslash}"
 VARS verify_{name} src_file="{src_file}"
@@ -144,6 +136,8 @@ SCRIPT POST verify_{name} {xfer_py} verify --json=verify_commands_{fileidx}.json
 
 
 _SIMPLE_FNAME_RE = re.compile("^[0-9A-Za-z_./:\-]+$")
+
+
 def simple_fname(fname):
     return _SIMPLE_FNAME_RE.match(fname)
 
@@ -158,7 +152,7 @@ def search_path(exec_name):
 def read_requirements_file(requirements_file):
     requirements = None
     if requirements_file is not None:
-        with open(requirements_file, 'r') as f:
+        with open(requirements_file, "r") as f:
             requirements = f.readline().rstrip()
     return requirements
 
@@ -170,20 +164,41 @@ def parse_args():
     parser_sync = subparsers.add_parser("sync")
     parser_sync.add_argument("src")
     parser_sync.add_argument("dest")
-    parser_sync.add_argument("--working-dir", help="Directory to place working HTCondor files.",
-        default="./scratch_dir", dest="working_dir")
-    parser_sync.add_argument("--requirements",
-        help="Submit file requirements (e.g. 'UniqueName == \"MyLab0001\"')")
-    parser_sync.add_argument("--requirements_file", help="File containing submit file requirements")
-    parser_sync.add_argument("--unique-id", help="Do not submit if jobs with UniqueId already found in queue",
-        dest="unique_id")
-    parser_sync.add_argument("--test-mode", help="Testing mode (only transfers small files)",
-        default=False, action="store_true", dest="test_mode")
+    parser_sync.add_argument(
+        "--working-dir",
+        help="Directory to place working HTCondor files.",
+        default="./scratch_dir",
+        dest="working_dir",
+    )
+    parser_sync.add_argument(
+        "--requirements",
+        help="Submit file requirements (e.g. 'UniqueName == \"MyLab0001\"')",
+    )
+    parser_sync.add_argument(
+        "--requirements_file", help="File containing submit file requirements"
+    )
+    parser_sync.add_argument(
+        "--unique-id",
+        help="Do not submit if jobs with UniqueId already found in queue",
+        dest="unique_id",
+    )
+    parser_sync.add_argument(
+        "--test-mode",
+        help="Testing mode (only transfers small files)",
+        default=False,
+        action="store_true",
+        dest="test_mode",
+    )
 
     parser_generate = subparsers.add_parser("generate")
     parser_generate.add_argument("src")
-    parser_generate.add_argument("--test-mode", help="Testing mode (only transfers small files)",
-        default=False, action="store_true", dest="test_mode")
+    parser_generate.add_argument(
+        "--test-mode",
+        help="Testing mode (only transfers small files)",
+        default=False,
+        action="store_true",
+        dest="test_mode",
+    )
 
     parser_subdag = subparsers.add_parser("write_subdag")
     parser_subdag.add_argument("source_prefix")
@@ -192,10 +207,19 @@ def parse_args():
     parser_subdag.add_argument("dest_manifest")
     parser_subdag.add_argument("transfer_manifest")
     parser_subdag.add_argument("--requirements", help="Submit file requirements")
-    parser_subdag.add_argument("--requirements_file", help="File containing submit file requirements")
-    parser_subdag.add_argument("--unique-id", help="Set UniqueId in submitted jobs", dest="unique_id")
-    parser_subdag.add_argument("--test-mode", help="Testing mode (only transfers small files)",
-        default=False, action="store_true", dest="test_mode")
+    parser_subdag.add_argument(
+        "--requirements_file", help="File containing submit file requirements"
+    )
+    parser_subdag.add_argument(
+        "--unique-id", help="Set UniqueId in submitted jobs", dest="unique_id"
+    )
+    parser_subdag.add_argument(
+        "--test-mode",
+        help="Testing mode (only transfers small files)",
+        default=False,
+        action="store_true",
+        dest="test_mode",
+    )
 
     parser_exec = subparsers.add_parser("exec")
     parser_exec.add_argument("src")
@@ -205,10 +229,10 @@ def parse_args():
 
     parser_verify = subparsers.add_parser("verify")
     # SCRIPT POST xfer_{name} {xfer_py} verify {dest_prefix} {dest} {src_file_noslash}.metadata {transfer_manifest}
-    #parser_verify.add_argument("dest_prefix")
-    #parser_verify.add_argument("dest")
-    #parser_verify.add_argument("metadata")
-    #parser_verify.add_argument("metadata_summary")
+    # parser_verify.add_argument("dest_prefix")
+    # parser_verify.add_argument("dest")
+    # parser_verify.add_argument("metadata")
+    # parser_verify.add_argument("metadata_summary")
     parser_verify.add_argument("--json", dest="json")
     parser_verify.add_argument("--fileid", dest="fileid")
 
@@ -224,16 +248,23 @@ def generate_file_listing(src, manifest, test_mode=False):
             for fname in fnames:
                 full_fname = os.path.normpath(os.path.join(root, fname))
                 size = os.stat(full_fname).st_size
-                if test_mode and size > 50*1024*1024:
+                if test_mode and size > 50 * 1024 * 1024:
                     continue
                 if simple_fname(full_fname):
                     fp.write("{} {}\n".format(full_fname, size))
                 else:
-                    info = {'name': full_fname, 'size': size}
+                    info = {"name": full_fname, "size": size}
                     fp.write("{}\n".format(json.dumps(info)))
 
 
-def submit_parent_dag(working_dir, source_dir, dest_dir, requirements=None, test_mode=False, unique_id=None):
+def submit_parent_dag(
+    working_dir,
+    source_dir,
+    dest_dir,
+    requirements=None,
+    test_mode=False,
+    unique_id=None,
+):
     try:
         os.makedirs(os.path.join(working_dir, "calc_work"))
     except OSError as oe:
@@ -244,21 +275,38 @@ def submit_parent_dag(working_dir, source_dir, dest_dir, requirements=None, test
     full_exec_path = os.path.join(os.path.abspath(info[0]), info[1])
 
     if requirements is not None:
-        with open(os.path.join(working_dir, "calc_work", "requirements.txt"), "w") as fd:
+        with open(
+            os.path.join(working_dir, "calc_work", "requirements.txt"), "w"
+        ) as fd:
             fd.write(requirements)
 
     with open(os.path.join(working_dir, "xfer.dag"), "w") as fd:
-        fd.write(PARENT_DAG.format(exec_py=full_exec_path, source_prefix=source_dir,
-            dest_prefix=dest_dir, other_args="--test-mode" if test_mode else "",
-            transfer_manifest=os.path.join(dest_dir, "transfer_manifest.txt"),
-            requirements="--requirements_file=requirements.txt" if requirements is not None else "",
-            unique_id="--unique-id={}".format(unique_id) if unique_id is not None else ""))
+        fd.write(
+            PARENT_DAG.format(
+                exec_py=full_exec_path,
+                source_prefix=source_dir,
+                dest_prefix=dest_dir,
+                other_args="--test-mode" if test_mode else "",
+                transfer_manifest=os.path.join(dest_dir, "transfer_manifest.txt"),
+                requirements="--requirements_file=requirements.txt"
+                if requirements is not None
+                else "",
+                unique_id="--unique-id={}".format(unique_id)
+                if unique_id is not None
+                else "",
+            )
+        )
 
     with open(os.path.join(working_dir, "calc_work", "calc_work.sub"), "w") as fd:
-        fd.write(CALC_WORK_JOB.format(exec_py=full_exec_path, source_dir=source_dir,
-            other_args="--test-mode" if test_mode else "",
-            requirements=requirements if requirements is not None else "True",
-            unique_id=unique_id if unique_id is not None else ""))
+        fd.write(
+            CALC_WORK_JOB.format(
+                exec_py=full_exec_path,
+                source_dir=source_dir,
+                other_args="--test-mode" if test_mode else "",
+                requirements=requirements if requirements is not None else "True",
+                unique_id=unique_id if unique_id is not None else "",
+            )
+        )
 
     dagman = search_path("condor_dagman")
     if not dagman:
@@ -266,21 +314,23 @@ def submit_parent_dag(working_dir, source_dir, dest_dir, requirements=None, test
         sys.exit(1)
 
     submit_dict = {
-        b"universe":                    b"scheduler",
-        b"executable":                  dagman.encode('utf-8'),
-        b"output":                      b"xfer.dag.lib.out",
-        b"error":                       b"xfer.dag.lib.err",
-        b"log":                         b"xfer.dag.dagman.log",
-        b"remove_kill_Sig":             b"SIGUSR1",
+        b"universe": b"scheduler",
+        b"executable": dagman.encode("utf-8"),
+        b"output": b"xfer.dag.lib.out",
+        b"error": b"xfer.dag.lib.err",
+        b"log": b"xfer.dag.dagman.log",
+        b"remove_kill_Sig": b"SIGUSR1",
         b"+OtherJobRemoveRequirements": b'"DAGManJobId =?= $(cluster)"',
-        b"on_exit_remove":              b'(ExitSignal =?= 11 || (ExitCode =!= UNDEFINED && '
-                                        b'ExitCode >=0 && ExitCode <= 2))',
-        b"arguments":                   b"\"-p 0 -f -l . -Lockfile xfer.dag.lock -AutoRescue 1 -DoRescueFrom 0"
-                                        b" -Dag xfer.dag -Suppress_notification -Dagman /usr/bin/condor_dagman"
-                                        b" -CsdVersion {}\"".format(htcondor.version().replace(" ", "' '")),
-        b"environment":                 b"_CONDOR_SCHEDD_ADDRESS_FILE={};_CONDOR_MAX_DAGMAN_LOG=0;"
-                                        b"_CONDOR_SCHEDD_DAEMON_AD_FILE={};_CONDOR_DAGMAN_LOG=xfer.dag.dagman.out".format(
-            htcondor.param[b'SCHEDD_ADDRESS_FILE'], htcondor.param[b'SCHEDD_DAEMON_AD_FILE'])
+        b"on_exit_remove": b"(ExitSignal =?= 11 || (ExitCode =!= UNDEFINED && "
+        b"ExitCode >=0 && ExitCode <= 2))",
+        b"arguments": b'"-p 0 -f -l . -Lockfile xfer.dag.lock -AutoRescue 1 -DoRescueFrom 0'
+        b" -Dag xfer.dag -Suppress_notification -Dagman /usr/bin/condor_dagman"
+        b' -CsdVersion {}"'.format(htcondor.version().replace(" ", "' '")),
+        b"environment": b"_CONDOR_SCHEDD_ADDRESS_FILE={};_CONDOR_MAX_DAGMAN_LOG=0;"
+        b"_CONDOR_SCHEDD_DAEMON_AD_FILE={};_CONDOR_DAGMAN_LOG=xfer.dag.dagman.out".format(
+            htcondor.param[b"SCHEDD_ADDRESS_FILE"],
+            htcondor.param[b"SCHEDD_DAEMON_AD_FILE"],
+        ),
     }
 
     schedd = htcondor.Schedd()
@@ -306,29 +356,48 @@ def parse_manifest(prefix, manifest, log_name):
                 continue
             if line.startswith("{"):
                 info = json.loads(line)
-                if 'name' not in info:
-                    raise Exception("Manifest line missing 'name' key.  Current line: %s" % line)
-                fname = info['name']
-                if 'size' not in info:
-                    raise Exception("Manifest line missing 'size' key.  Currenty line: %s" % line)
-                size = int(info['size'])
+                if "name" not in info:
+                    raise Exception(
+                        "Manifest line missing 'name' key.  Current line: %s" % line
+                    )
+                fname = info["name"]
+                if "size" not in info:
+                    raise Exception(
+                        "Manifest line missing 'size' key.  Currenty line: %s" % line
+                    )
+                size = int(info["size"])
             else:
                 info = line.strip().split()
                 if len(info) != 2:
-                    raise Exception("Manifest lines must have two columns.  Current line: %s" % line)
-                fname = info[0].decode('utf-8')
+                    raise Exception(
+                        "Manifest lines must have two columns.  Current line: %s" % line
+                    )
+                fname = info[0].decode("utf-8")
                 size = int(info[1])
             if not fname.startswith(prefix):
-                logging.error("%s file (%s) does not start with specified prefix", log_name, fname)
-            fname = fname[len(prefix) + 1:]
+                logging.error(
+                    "%s file (%s) does not start with specified prefix", log_name, fname
+                )
+            fname = fname[len(prefix) + 1 :]
             if not fname:
-                logging.warning("%s file, stripped of prefix (%s), is empty", log_name, prefix)
+                logging.warning(
+                    "%s file, stripped of prefix (%s), is empty", log_name, prefix
+                )
                 continue
             files[fname] = size
     return files
 
 
-def write_subdag(source_prefix, source_manifest, dest_prefix, dest_manifest, transfer_manifest, requirements=None, test_mode=False, unique_id=None):
+def write_subdag(
+    source_prefix,
+    source_manifest,
+    dest_prefix,
+    dest_manifest,
+    transfer_manifest,
+    requirements=None,
+    test_mode=False,
+    unique_id=None,
+):
     src_files = parse_manifest(source_prefix, source_manifest, "Source")
 
     generate_file_listing(dest_prefix, "destination_manifest.txt")
@@ -346,22 +415,21 @@ def write_subdag(source_prefix, source_manifest, dest_prefix, dest_manifest, tra
         except OSError as oe:
             if oe.errno != errno.EEXIST:
                 raise
-        fd = os.open(transfer_manifest, os.O_CREAT|os.O_RDONLY)
+        fd = os.open(transfer_manifest, os.O_CREAT | os.O_RDONLY)
         os.close(fd)
 
     files_verified = set()
     with open(transfer_manifest, "r") as fp:
         for line in fp.readlines():
             line = line.strip()
-            if not line or line[0] == '#':
+            if not line or line[0] == "#":
                 continue
             info = line.strip().split()
-            if info[0] != 'TRANSFER_VERIFIED':
+            if info[0] != "TRANSFER_VERIFIED":
                 continue
-            if info[1] == '{':
+            if info[1] == "{":
                 info = json.loads(" ".join(info[1:]))
-                if 'name' not in info or 'digest' not in info or \
-                        'size' not in info:
+                if "name" not in info or "digest" not in info or "size" not in info:
                     continue
             elif len(info) != 5:
                 continue
@@ -381,13 +449,21 @@ def write_subdag(source_prefix, source_manifest, dest_prefix, dest_manifest, tra
     full_exec_path = os.path.join(os.path.abspath(info[0]), info[1])
 
     with open("xfer_file.sub", "w") as fp:
-        fp.write(XFER_FILE_JOB.format(xfer_py=full_exec_path,
-            requirements=requirements if requirements is not None else "True",
-            unique_id=unique_id if unique_id is not None else ""))
+        fp.write(
+            XFER_FILE_JOB.format(
+                xfer_py=full_exec_path,
+                requirements=requirements if requirements is not None else "True",
+                unique_id=unique_id if unique_id is not None else "",
+            )
+        )
     with open("verify_file.sub", "w") as fp:
-        fp.write(VERIFY_FILE_JOB.format(xfer_py=full_exec_path,
-            requirements=requirements if requirements is not None else "True",
-            unique_id=unique_id if unique_id is not None else ""))
+        fp.write(
+            VERIFY_FILE_JOB.format(
+                xfer_py=full_exec_path,
+                requirements=requirements if requirements is not None else "True",
+                unique_id=unique_id if unique_id is not None else "",
+            )
+        )
 
     idx = 0
     dest_dirs = set()
@@ -395,7 +471,9 @@ def write_subdag(source_prefix, source_manifest, dest_prefix, dest_manifest, tra
     cur_jsonidx = 0
     cmd_info = {}
     with open("do_work.dag", "w") as fp:
-        fp.write(DO_WORK_DAG_HEADER.format("MAXJOBS TRANSFER_JOBS 1" if test_mode else ""))
+        fp.write(
+            DO_WORK_DAG_HEADER.format("MAXJOBS TRANSFER_JOBS 1" if test_mode else "")
+        )
         files_to_xfer = list(files_to_xfer)
         files_to_xfer.sort()
         for fname in files_to_xfer:
@@ -418,11 +496,18 @@ def write_subdag(source_prefix, source_manifest, dest_prefix, dest_manifest, tra
                 "src_file_noslash": src_file_noslash,
                 "dest": dest,
                 "transfer_manifest": transfer_manifest,
-                "dest_prefix": dest_prefix
+                "dest_prefix": dest_prefix,
             }
-            fp.write(DO_WORK_DAG_XFER_SNIPPET.format(name=idx, fileidx=cur_jsonidx,
-                xfer_py=full_exec_path, src_file=src_file, src_file_noslash=src_file_noslash,
-		dest=dest))
+            fp.write(
+                DO_WORK_DAG_XFER_SNIPPET.format(
+                    name=idx,
+                    fileidx=cur_jsonidx,
+                    xfer_py=full_exec_path,
+                    src_file=src_file,
+                    src_file_noslash=src_file_noslash,
+                    dest=dest,
+                )
+            )
 
         with open("xfer_commands_{}.json".format(cur_jsonidx), "w") as cmd_fp:
             json.dump(cmd_info, cmd_fp)
@@ -447,11 +532,18 @@ def write_subdag(source_prefix, source_manifest, dest_prefix, dest_manifest, tra
                 "src_file_noslash": src_file_noslash,
                 "dest": dest,
                 "transfer_manifest": transfer_manifest,
-                "dest_prefix": dest_prefix
+                "dest_prefix": dest_prefix,
             }
-            fp.write(DO_WORK_DAG_VERIFY_SNIPPET.format(name=idx, fileidx=cur_jsonidx,
-                xfer_py=full_exec_path, src_file=src_file, src_file_noslash=src_file_noslash,
-                dest=dest))
+            fp.write(
+                DO_WORK_DAG_VERIFY_SNIPPET.format(
+                    name=idx,
+                    fileidx=cur_jsonidx,
+                    xfer_py=full_exec_path,
+                    src_file=src_file,
+                    src_file_noslash=src_file_noslash,
+                    dest=dest,
+                )
+            )
 
         with open("verify_commands_{}.json".format(cur_jsonidx), "w") as cmd_fp:
             json.dump(cmd_info, cmd_fp)
@@ -466,8 +558,17 @@ def write_subdag(source_prefix, source_manifest, dest_prefix, dest_manifest, tra
     bytes_to_transfer = sum(src_files[fname] for fname in files_to_xfer)
     bytes_to_verify = sum(src_files[fname] for fname in files_to_verify)
     with open(transfer_manifest, "a") as fp:
-        fp.write("SYNC_REQUEST {} files_at_source={} files_to_transfer={} bytes_to_transfer={} files_to_verify={} bytes_to_verify={} timestamp={}\n".format(
-            source_prefix, len(src_files), len(files_to_xfer), bytes_to_transfer, len(files_to_verify), bytes_to_verify, time.time()))
+        fp.write(
+            "SYNC_REQUEST {} files_at_source={} files_to_transfer={} bytes_to_transfer={} files_to_verify={} bytes_to_verify={} timestamp={}\n".format(
+                source_prefix,
+                len(src_files),
+                len(files_to_xfer),
+                bytes_to_transfer,
+                len(files_to_verify),
+                bytes_to_verify,
+                time.time(),
+            )
+        )
         for fname in files_to_xfer:
             if simple_fname(fname):
                 fp.write("TRANSFER_REQUEST {} {}\n".format(fname, src_files[fname]))
@@ -483,7 +584,7 @@ def write_subdag(source_prefix, source_manifest, dest_prefix, dest_manifest, tra
 
 
 def xfer_exec(src):
-    if '_CONDOR_JOB_AD' not in os.environ:
+    if "_CONDOR_JOB_AD" not in os.environ:
         print("This executable must be run within the HTCondor runtime environment.")
         sys.exit(1)
 
@@ -491,19 +592,23 @@ def xfer_exec(src):
     src_fd = open(src, "r")
     dest_fd = open("file0", "w")
     file_size = os.fstat(src_fd.fileno()).st_size
-    logging.info("There are %.2fMB to copy", file_size / 1024. / 1024.)
+    logging.info("There are %.2fMB to copy", file_size / 1024.0 / 1024.0)
     last_log = time.time()
-    buf = src_fd.read(1024*1024)
+    buf = src_fd.read(1024 * 1024)
     hash_obj = hashlib.sha1()
     byte_count = len(buf)
     while len(buf) > 0:
         hash_obj.update(buf)
         dest_fd.write(buf)
-        buf = src_fd.read(1024*1024)
+        buf = src_fd.read(1024 * 1024)
         now = time.time()
-        if (now - last_log > 5):
-            logging.info("Copied %.2f of %.2fMB; %.1f%% done", byte_count / 1024. / 1024., file_size / 1024. / 1024.,
-                (byte_count / float(file_size)) * 100)
+        if now - last_log > 5:
+            logging.info(
+                "Copied %.2f of %.2fMB; %.1f%% done",
+                byte_count / 1024.0 / 1024.0,
+                file_size / 1024.0 / 1024.0,
+                (byte_count / float(file_size)) * 100,
+            )
             last_log = now
         byte_count += len(buf)
 
@@ -516,32 +621,40 @@ def xfer_exec(src):
     logging.info("File metadata: hash=%s, size=%d", hash_obj.hexdigest(), byte_count)
     with open("metadata", "w") as metadata_fd:
         if simple_fname(src):
-            metadata_fd.write("{} {} {}\n".format(src, hash_obj.hexdigest(), byte_count).encode('utf-8'))
+            metadata_fd.write(
+                "{} {} {}\n".format(src, hash_obj.hexdigest(), byte_count).encode(
+                    "utf-8"
+                )
+            )
         else:
             info = {"name": src, "digest": hash_obj.hexdigest(), "size": byte_count}
             metadata_fd.write("{}\n".format(json.dumps(info)))
 
 
 def verify_remote(src):
-    if '_CONDOR_JOB_AD' not in os.environ:
+    if "_CONDOR_JOB_AD" not in os.environ:
         print("This executable must be run within the HTCondor runtime environment.")
         sys.exit(1)
 
     logging.info("About to verify %s", src)
     src_fd = open(src, "r")
     file_size = os.fstat(src_fd.fileno()).st_size
-    logging.info("There are %.2fMB to verify", file_size / 1024. / 1024.)
+    logging.info("There are %.2fMB to verify", file_size / 1024.0 / 1024.0)
     last_log = time.time()
-    buf = src_fd.read(1024*1024)
+    buf = src_fd.read(1024 * 1024)
     hash_obj = hashlib.sha1()
     byte_count = len(buf)
     while len(buf) > 0:
         hash_obj.update(buf)
-        buf = src_fd.read(1024*1024)
+        buf = src_fd.read(1024 * 1024)
         now = time.time()
-        if (now - last_log > 5):
-            logging.info("Copied %.2f of %.2fMB; %.1f%% done", byte_count / 1024. / 1024., file_size / 1024. / 1024.,
-                (byte_count / float(file_size)) * 100)
+        if now - last_log > 5:
+            logging.info(
+                "Copied %.2f of %.2fMB; %.1f%% done",
+                byte_count / 1024.0 / 1024.0,
+                file_size / 1024.0 / 1024.0,
+                (byte_count / float(file_size)) * 100,
+            )
             last_log = now
         byte_count += len(buf)
 
@@ -551,7 +664,11 @@ def verify_remote(src):
     logging.info("File metadata: hash=%s, size=%d", hash_obj.hexdigest(), byte_count)
     with open("metadata", "w") as metadata_fd:
         if simple_fname(src):
-            metadata_fd.write("{} {} {}\n".format(src, hash_obj.hexdigest(), byte_count).encode('utf-8'))
+            metadata_fd.write(
+                "{} {} {}\n".format(src, hash_obj.hexdigest(), byte_count).encode(
+                    "utf-8"
+                )
+            )
         else:
             info = {"name": src, "digest": hash_obj.hexdigest(), "size": byte_count}
             metadata_fd.write("{}\n".format(json.dumps(info)))
@@ -567,60 +684,88 @@ def verify(dest_prefix, dest, metadata, metadata_summary):
         if not contents:
             logging.error("Metadata file is empty")
             sys.exit(1)
-        if contents[0] == '{':
+        if contents[0] == "{":
             info = json.loads(contents)
-            if 'name' not in info or 'digest' not in info or 'size' not in info:
+            if "name" not in info or "digest" not in info or "size" not in info:
                 logging.error("Metadata file format incorrect; missing keys")
                 sys.exit(1)
-            src_fname = info['name']
-            src_hexdigest = info['digest'].encode("ascii")
-            src_size = int(info['size'])
+            src_fname = info["name"]
+            src_hexdigest = info["digest"].encode("ascii")
+            src_size = int(info["size"])
         else:
             info = contents.strip().split()
             if len(info) != 3:
                 logging.error("Metadata file format incorrect")
                 sys.exit(1)
-            src_fname = info[0].decode('utf-8')
+            src_fname = info[0].decode("utf-8")
             src_hexdigest = info[1]
             src_size = int(info[2])
 
-    relative_fname = dest[len(dest_prefix) + 1:]
+    relative_fname = dest[len(dest_prefix) + 1 :]
 
     logging.info("About to verify contents of %s", dest)
     dest_fd = open(dest, "r")
     dest_size = os.fstat(dest_fd.fileno()).st_size
     if src_size != dest_size:
-        logging.error("Copied file size (%d bytes) does not match source file size (%d bytes)", dest_size, src_size)
+        logging.error(
+            "Copied file size (%d bytes) does not match source file size (%d bytes)",
+            dest_size,
+            src_size,
+        )
         sys.exit(2)
-    logging.info("There are %.2fMB to verify", dest_size / 1024. / 1024.)
+    logging.info("There are %.2fMB to verify", dest_size / 1024.0 / 1024.0)
     last_log = time.time()
-    buf = dest_fd.read(1024*1024)
+    buf = dest_fd.read(1024 * 1024)
     hash_obj = hashlib.sha1()
     byte_count = len(buf)
     while len(buf) > 0:
         hash_obj.update(buf)
-        buf = dest_fd.read(1024*1024)
+        buf = dest_fd.read(1024 * 1024)
         now = time.time()
         if now - last_log > 5:
-            logging.info("Verified %.2f of %.2fMB; %.1f%% done", byte_count / 1024. / 1024., dest_size / 1024. / 1024.,
-                (byte_count / float(dest_size)) * 100)
+            logging.info(
+                "Verified %.2f of %.2fMB; %.1f%% done",
+                byte_count / 1024.0 / 1024.0,
+                dest_size / 1024.0 / 1024.0,
+                (byte_count / float(dest_size)) * 100,
+            )
             last_log = now
         byte_count += len(buf)
 
     dest_fd.close()
     if src_hexdigest != hash_obj.hexdigest():
-        logging.info("Destination file (%s) has incorrect SHA1 digest of %s, which does not match"
-            " source file %s (digest %s)", dest, src_hexdigest, src_fname, hash_obj.hexdigest())
+        logging.info(
+            "Destination file (%s) has incorrect SHA1 digest of %s, which does not match"
+            " source file %s (digest %s)",
+            dest,
+            src_hexdigest,
+            src_fname,
+            hash_obj.hexdigest(),
+        )
         sys.exit(1)
     else:
-        logging.info("File verification successful: Destination (%s) and source (%s) have matching"
-            " SHA1 digest (%s)", dest, src_fname, src_hexdigest)
+        logging.info(
+            "File verification successful: Destination (%s) and source (%s) have matching"
+            " SHA1 digest (%s)",
+            dest,
+            src_fname,
+            src_hexdigest,
+        )
 
     with open(metadata_summary, "a") as md_fd:
         if simple_fname(relative_fname):
-            md_fd.write("TRANSFER_VERIFIED {} {} {} {}\n".format(relative_fname, src_hexdigest, src_size, int(time.time())).encode('utf-8'))
+            md_fd.write(
+                "TRANSFER_VERIFIED {} {} {} {}\n".format(
+                    relative_fname, src_hexdigest, src_size, int(time.time())
+                ).encode("utf-8")
+            )
         else:
-            info = {"name": relative_fname, "digest": src_hexdigest, "size": src_size, "timestamp": int(time.time())}
+            info = {
+                "name": relative_fname,
+                "digest": src_hexdigest,
+                "size": src_size,
+                "timestamp": int(time.time()),
+            }
             md_fd.write("TRANSFER_VERIFIED {}\n".format(json.dumps(info)))
         os.fsync(md_fd.fileno())
 
@@ -637,7 +782,7 @@ def verify(dest_prefix, dest, metadata, metadata_summary):
 def analyze(transfer_manifest):
     sync_request_start = None
     idx = -1
-    sync_request = {'files': {}, 'xfer_files': set(), 'verified_files': {}}
+    sync_request = {"files": {}, "xfer_files": set(), "verified_files": {}}
     dest_dir = os.path.abspath(os.path.split(transfer_manifest)[0])
     sync_count = 0
 
@@ -646,57 +791,78 @@ def analyze(transfer_manifest):
             idx += 1
             info = line.strip().split()
             # Format: SYNC_REQUEST {} files_at_source={} files_to_transfer={} bytes_to_transfer={} files_to_verify={} bytes_to_verify={} timestamp={}
-            if info[0] == 'SYNC_REQUEST':
+            if info[0] == "SYNC_REQUEST":
                 sync_count += 1
-                #if sync_request_start is not None:
+                # if sync_request_start is not None:
                 #    logging.error("Sync request started at line %d but never finished; inconsistent log",
                 #        sync_request_start)
                 #    sys.exit(4)
                 sync_request_start = idx
                 for entry in info[2:]:
                     key, val = entry.split("=")
-                    if key == 'timestamp':
+                    if key == "timestamp":
                         continue
                     sync_request[key] = int(val)
-            elif info[0] == 'TRANSFER_REQUEST' or info[0] == 'VERIFY_REQUEST': # Format: TRANSFER_REQUEST fname size
+            elif (
+                info[0] == "TRANSFER_REQUEST" or info[0] == "VERIFY_REQUEST"
+            ):  # Format: TRANSFER_REQUEST fname size
                 if sync_request_start is None:
-                    logging.error("Transfer request found at line %d before sync started; inconsistent log", idx)
+                    logging.error(
+                        "Transfer request found at line %d before sync started; inconsistent log",
+                        idx,
+                    )
                     sys.exit(4)
-                if info[1][0] == '{':
+                if info[1][0] == "{":
                     local_info = json.loads(" ".join(info[1:]))
-                    size = int(local_info['size'])
-                    fname = local_info['name']
+                    size = int(local_info["size"])
+                    fname = local_info["name"]
                 else:
                     size = int(info[2])
                     fname = info[1]
                 # File was previously verified.
-                if fname in sync_request['verified_files'] and sync_request['verified_files'][fname] == size:
+                if (
+                    fname in sync_request["verified_files"]
+                    and sync_request["verified_files"][fname] == size
+                ):
                     continue
-                sync_request['files'][fname] = size
-                if info[0] == 'TRANSFER_REQUEST':
-                    if info[1][0] == '{':
+                sync_request["files"][fname] = size
+                if info[0] == "TRANSFER_REQUEST":
+                    if info[1][0] == "{":
                         local_info = json.loads(" ".join(info[1:]))
-                        sync_request['xfer_files'].add(local_info['name'])
+                        sync_request["xfer_files"].add(local_info["name"])
                     else:
-                        sync_request['xfer_files'].add(info[1])
-            elif info[0] == 'TRANSFER_VERIFIED': # Format: TRANSFER_VERIFIED relative_fname hexdigest size timestamp:
+                        sync_request["xfer_files"].add(info[1])
+            elif (
+                info[0] == "TRANSFER_VERIFIED"
+            ):  # Format: TRANSFER_VERIFIED relative_fname hexdigest size timestamp:
                 if sync_request_start is None:
-                    logging.error("Transfer verification found at line %d before sync started; inconsistent log", idx)
+                    logging.error(
+                        "Transfer verification found at line %d before sync started; inconsistent log",
+                        idx,
+                    )
                     sys.exit(4)
-                if info[1][0] == '{':
+                if info[1][0] == "{":
                     local_info = json.loads(" ".join(info[1:]))
-                    fname = local_info['name']
-                    size = int(local_info['size'])
+                    fname = local_info["name"]
+                    size = int(local_info["size"])
                 else:
                     fname = info[1]
                     size = int(info[3])
-                if fname in sync_request['verified_files'] and sync_request['verified_files'][fname] == size:
+                if (
+                    fname in sync_request["verified_files"]
+                    and sync_request["verified_files"][fname] == size
+                ):
                     continue
-                if fname not in sync_request['files']:
+                if fname not in sync_request["files"]:
                     logging.error("File %s verified but was not requested.", fname)
                     sys.exit(4)
-                if sync_request['files'][fname] != size:
-                    logging.error("Verified file size %d of %s is different than anticipated", size, fname, sync_request['files'][fname])
+                if sync_request["files"][fname] != size:
+                    logging.error(
+                        "Verified file size %d of %s is different than anticipated",
+                        size,
+                        fname,
+                        sync_request["files"][fname],
+                    )
                     sys.exit(4)
                 try:
                     local_size = os.stat(os.path.join(dest_dir, fname)).st_size
@@ -704,33 +870,61 @@ def analyze(transfer_manifest):
                     logging.error("Unable to verify size of %s: %s", fname, str(oe))
                     sys.exit(4)
                 if local_size != size:
-                    logging.error("Local size of %d of %s does not match anticipated size %d.", local_size, fname, size)
+                    logging.error(
+                        "Local size of %d of %s does not match anticipated size %d.",
+                        local_size,
+                        fname,
+                        size,
+                    )
                     sys.exit(4)
-                if fname in sync_request['xfer_files']:
-                    sync_request['files_to_transfer'] -= 1
-                    sync_request['bytes_to_transfer'] -= size
+                if fname in sync_request["xfer_files"]:
+                    sync_request["files_to_transfer"] -= 1
+                    sync_request["bytes_to_transfer"] -= size
                 else:
-                    sync_request['files_to_verify'] -= 1
-                    sync_request['bytes_to_verify'] -= size
-                del sync_request['files'][fname]
-                sync_request['verified_files'][fname] = size
-            elif info[0] == 'SYNC_DONE':
+                    sync_request["files_to_verify"] -= 1
+                    sync_request["bytes_to_verify"] -= size
+                del sync_request["files"][fname]
+                sync_request["verified_files"][fname] = size
+            elif info[0] == "SYNC_DONE":
                 if sync_request_start is None:
-                    logging.error("Transfer request found at line %d before sync started; inconsistent log", idx)
+                    logging.error(
+                        "Transfer request found at line %d before sync started; inconsistent log",
+                        idx,
+                    )
                     sys.exit(4)
 
-                if sync_request['files_to_verify'] or sync_request['bytes_to_verify'] or sync_request['files'] or \
-                        sync_request['files_to_transfer'] or sync_request['bytes_to_transfer']:
-                    logging.error("SYNC_DONE but there is work remaining: %s", str(sync_request))
+                if (
+                    sync_request["files_to_verify"]
+                    or sync_request["bytes_to_verify"]
+                    or sync_request["files"]
+                    or sync_request["files_to_transfer"]
+                    or sync_request["bytes_to_transfer"]
+                ):
+                    logging.error(
+                        "SYNC_DONE but there is work remaining: %s", str(sync_request)
+                    )
                     sys.exit(4)
                 sync_request_start = None
-                sync_request = {'files': {}, 'xfer_files': set(), 'verified_files': {}}
-        if sync_request_start is not None and (sync_request['files_to_verify'] or sync_request['bytes_to_verify'] or sync_request['files'] or \
-                sync_request['files_to_transfer'] or sync_request['bytes_to_transfer']):
+                sync_request = {"files": {}, "xfer_files": set(), "verified_files": {}}
+        if sync_request_start is not None and (
+            sync_request["files_to_verify"]
+            or sync_request["bytes_to_verify"]
+            or sync_request["files"]
+            or sync_request["files_to_transfer"]
+            or sync_request["bytes_to_transfer"]
+        ):
             logging.error("Sync not done! Work remaining.")
-            logging.error("- Files to transfer: %s (bytes %d)", sync_request['files_to_transfer'], sync_request['bytes_to_transfer'])
-            logging.error("- Files to verify: %s (bytes %d)", sync_request['files_to_verify'], sync_request['bytes_to_verify'])
-            logging.error("Inconsistent files: {}".format(str(sync_request['files'])))
+            logging.error(
+                "- Files to transfer: %s (bytes %d)",
+                sync_request["files_to_transfer"],
+                sync_request["bytes_to_transfer"],
+            )
+            logging.error(
+                "- Files to verify: %s (bytes %d)",
+                sync_request["files_to_verify"],
+                sync_request["bytes_to_verify"],
+            )
+            logging.error("Inconsistent files: {}".format(str(sync_request["files"])))
             sys.exit(4)
     if sync_request_start is not None:
         with open(transfer_manifest, "a") as fp:
@@ -744,42 +938,81 @@ def analyze(transfer_manifest):
 
 
 def main():
-    logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
+    logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
 
     args = parse_args()
 
     if args.cmd == "sync":
         if args.unique_id:
             schedd = htcondor.Schedd()
-            if len(schedd.query(constraint = 'UniqueId == "{}" && JobStatus =!= 4'.format(args.unique_id).encode(),
-                                attr_list = [], limit = 1)) > 0:
-                logging.warning('Jobs already found in queue with UniqueId == "%s", exiting', args.unique_id)
+            if (
+                len(
+                    schedd.query(
+                        constraint='UniqueId == "{}" && JobStatus =!= 4'.format(
+                            args.unique_id
+                        ).encode(),
+                        attr_list=[],
+                        limit=1,
+                    )
+                )
+                > 0
+            ):
+                logging.warning(
+                    'Jobs already found in queue with UniqueId == "%s", exiting',
+                    args.unique_id,
+                )
                 sys.exit()
         working_dir = args.working_dir if args.working_dir else os.getcwd()
-        print("Will synchronize %s at source to %s at destination" % (args.src, args.dest))
-        cluster_id = submit_parent_dag(working_dir, args.src, os.path.abspath(args.dest),
-            requirements=read_requirements_file(args.requirements_file) or args.requirements, test_mode=args.test_mode,
-            unique_id=args.unique_id)
+        print(
+            "Will synchronize %s at source to %s at destination" % (args.src, args.dest)
+        )
+        cluster_id = submit_parent_dag(
+            working_dir,
+            args.src,
+            os.path.abspath(args.dest),
+            requirements=read_requirements_file(args.requirements_file)
+            or args.requirements,
+            test_mode=args.test_mode,
+            unique_id=args.unique_id,
+        )
         print("Parent job running in cluster %d" % cluster_id)
     elif args.cmd == "generate":
         logging.info("Generating file listing for %s", args.src)
         generate_file_listing(args.src, "source_manifest.txt", test_mode=args.test_mode)
     elif args.cmd == "write_subdag":
-        logging.info("Generating SUBGDAG for transfer of %s->%s", args.source_prefix, args.dest_prefix)
-        write_subdag(args.source_prefix, args.source_manifest, args.dest_prefix, args.dest_manifest, args.transfer_manifest,
-            requirements=read_requirements_file(args.requirements_file) or args.requirements, test_mode=args.test_mode,
-            unique_id=args.unique_id)
+        logging.info(
+            "Generating SUBGDAG for transfer of %s->%s",
+            args.source_prefix,
+            args.dest_prefix,
+        )
+        write_subdag(
+            args.source_prefix,
+            args.source_manifest,
+            args.dest_prefix,
+            args.dest_manifest,
+            args.transfer_manifest,
+            requirements=read_requirements_file(args.requirements_file)
+            or args.requirements,
+            test_mode=args.test_mode,
+            unique_id=args.unique_id,
+        )
     elif args.cmd == "exec":
         xfer_exec(args.src)
     elif args.cmd == "verify":
         with open(args.json, "r") as fp:
             cmd_info = json.load(fp)
         info = cmd_info[args.fileid]
-        verify(info['dest_prefix'], info['dest'], '{}.metadata'.format(info['src_file_noslash']), info['transfer_manifest'])
+        verify(
+            info["dest_prefix"],
+            info["dest"],
+            "{}.metadata".format(info["src_file_noslash"]),
+            info["transfer_manifest"],
+        )
     elif args.cmd == "verify_remote":
         verify_remote(args.src)
     elif args.cmd == "analyze":
         analyze(args.transfer_manifest)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/xfer.py
+++ b/xfer.py
@@ -1107,9 +1107,8 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(format="%(asctime)s ~ %(message)s", level=logging.INFO)
-
     try:
+        logging.basicConfig(format="%(asctime)s ~ %(message)s", level=logging.INFO)
         main()
     except Exception as e:
         logging.exception("Error: {}".format(e))

--- a/xfer.py
+++ b/xfer.py
@@ -498,8 +498,6 @@ def write_inner_dag(
 
     ensure_destination_dirs_exist(dest_prefix, files_to_xfer)
 
-    print(source_prefix)
-    print(dest_prefix)
     xfer_cmd_info = make_cmd_info(
         files_to_xfer, source_prefix, dest_prefix, transfer_manifest_path
     )
@@ -681,8 +679,6 @@ def verify(
     src_fname = entry.name
     src_hexdigest = entry.digest
     src_size = entry.size
-
-    print(dest, dest_prefix)
 
     logging.info("About to verify contents of %s", dest)
 
@@ -1098,7 +1094,6 @@ def main():
         cmd_info = load_json(args.json)
         # Split the DAG job name to get the cmd_info key
         info = cmd_info[args.fileid.split(":")[-1]]
-        print("VERIFYINFO", info)
         verify(
             Path(info["dest_prefix"]),
             Path(info["dest"]),
@@ -1112,14 +1107,10 @@ def main():
 
 
 if __name__ == "__main__":
-    out = Path("/home/jtk/projects/htcondor_file_transfer/out")
-    with out.open(mode="a") as f, contextlib.redirect_stdout(
-        f
-    ), contextlib.redirect_stderr(f):
-        logging.basicConfig(format="%(asctime)s ~ %(message)s", level=logging.INFO)
+    logging.basicConfig(format="%(asctime)s ~ %(message)s", level=logging.INFO)
 
-        try:
-            main()
-        except Exception as e:
-            logging.exception("Error: {}".format(e))
-            sys.exit(1)
+    try:
+        main()
+    except Exception as e:
+        logging.exception("Error: {}".format(e))
+        sys.exit(1)

--- a/xfer.py
+++ b/xfer.py
@@ -7,7 +7,6 @@ execute host to a local destination on the submit host.
 
 import argparse
 import contextlib
-import errno
 import hashlib
 import logging
 import os
@@ -18,125 +17,46 @@ from pathlib import Path
 
 import htcondor
 import htcondor.dags as dags
+import classad
+
+
+KB = 2 ** 10
+MB = 2 ** 20
+GB = 2 ** 30
+TB = 2 ** 40
+
+METADATA_FILE_SIZE_LIMIT = 16 * KB
+SANDBOX_FILE_NAME = "file-for-xfer"
 
 THIS_FILE = Path(__file__).absolute()
-
-XFER_FILE_JOB = """
-universe = vanilla
-executable = {xfer_py}
-output = $(src_file_noslash).out
-error = $(src_file_noslash).err
-log = xfer_file.log
-Args = "exec '$(src_file)'"
-should_transfer_files = YES
-transfer_output_files = file0, metadata
-transfer_output_remaps = "file0 = $(dst_file); metadata = $(src_file_noslash).metadata"
-requirements = {requirements}
-+IS_TRANSFER_JOB = true
-+UniqueId = "{unique_id}"
-+WantFlocking = true
-request_disk = 1GB
-
-queue
-"""
-
-XFER_FILE_N_JOB = """
-universe = vanilla
-executable = {xfer_py}
-output = $(name).out
-error = $(name).err
-log = xfer_file.log
-Args = "exec_n --json '$(name)'"
-should_transfer_files = YES
-transfer_output_files = {file_list}, metadata
-transfer_output_remaps = "{file_list}; metadata = result_$(name).metadata"
-requirements = {requirements}
-+IS_TRANSFER_JOB = true
-+UniqueId = "{unique_id}"
-+WantFlocking = true
-request_disk = 1GB
-
-queue
-"""
-
-VERIFY_FILE_JOB = """
-universe = vanilla
-executable = {xfer_py}
-output = $(src_file_noslash).out
-error = $(src_file_noslash).err
-log = xfer_file.log
-Args = "verify_remote '$(src_file)'"
-should_transfer_files = YES
-transfer_output_files = metadata
-transfer_output_remaps = "metadata = $(src_file_noslash).metadata"
-requirements = {requirements}
-+IS_TRANSFER_JOB = true
-+UniqueId = "{unique_id}"
-+WantFlocking = true
-request_disk = 1GB
-
-queue
-"""
-
-DO_WORK_DAG_HEADER = """
-CATEGORY ALL_NODES TRANSFER_JOBS
-{}
-
-"""
-
-DO_WORK_DAG_XFER_SNIPPET = """
-JOB xfer_{name} xfer_file.sub
-VARS xfer_{name} src_file_noslash="{src_file_noslash}"
-VARS xfer_{name} src_file="{src_file}"
-VARS xfer_{name} dst_file="{dest}"
-SCRIPT POST xfer_{name} {xfer_py} verify --json=xfer_commands_{fileidx}.json --fileid={name}
-
-"""
-
-DO_WORK_DAG_VERIFY_SNIPPET = """
-JOB verify_{name} verify_file.sub
-VARS verify_{name} src_file_noslash="{src_file_noslash}"
-VARS verify_{name} src_file="{src_file}"
-VARS verify_{name} dst_file="{dest}"
-SCRIPT POST verify_{name} {xfer_py} verify --json=verify_commands_{fileidx}.json --fileid={name}
-
-"""
-
-
-def read_requirements_file(requirements_file):
-    requirements = None
-    if requirements_file is not None:
-        with open(requirements_file, "r") as f:
-            requirements = f.readline().rstrip()
-    return requirements
 
 
 def parse_args():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="cmd")
 
-    parser_sync = subparsers.add_parser("sync")
-    parser_sync.add_argument("src")
-    parser_sync.add_argument("dest")
-    parser_sync.add_argument(
+    sync = subparsers.add_parser("sync")
+    sync.add_argument("src")
+    sync.add_argument("dest")
+    sync.add_argument(
         "--working-dir",
         help="Directory to place working HTCondor files.",
         default="./scratch_dir",
         dest="working_dir",
     )
-    parser_sync.add_argument(
+    sync.add_argument(
         "--requirements",
         help="Submit file requirements (e.g. 'UniqueName == \"MyLab0001\"')",
     )
-    parser_sync.add_argument(
+    sync.add_argument(
         "--requirements_file", help="File containing submit file requirements"
     )
-    parser_sync.add_argument(
+    sync.add_argument(
         "--unique-id",
         help="Do not submit if jobs with UniqueId already found in queue",
         dest="unique_id",
     )
-    parser_sync.add_argument(
+    sync.add_argument(
         "--test-mode",
         help="Testing mode (only transfers small files)",
         default=False,
@@ -144,9 +64,9 @@ def parse_args():
         dest="test_mode",
     )
 
-    parser_generate = subparsers.add_parser("generate")
-    parser_generate.add_argument("src")
-    parser_generate.add_argument(
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("src")
+    generate.add_argument(
         "--test-mode",
         help="Testing mode (only transfers small files)",
         default=False,
@@ -154,20 +74,20 @@ def parse_args():
         dest="test_mode",
     )
 
-    parser_subdag = subparsers.add_parser("write_subdag")
-    parser_subdag.add_argument("source_prefix")
-    parser_subdag.add_argument("source_manifest")
-    parser_subdag.add_argument("dest_prefix")
-    parser_subdag.add_argument("dest_manifest")
-    parser_subdag.add_argument("transfer_manifest")
-    parser_subdag.add_argument("--requirements", help="Submit file requirements")
-    parser_subdag.add_argument(
+    subdag = subparsers.add_parser("write_subdag")
+    subdag.add_argument("source_prefix")
+    subdag.add_argument("source_manifest")
+    subdag.add_argument("dest_prefix")
+    subdag.add_argument("dest_manifest")
+    subdag.add_argument("transfer_manifest")
+    subdag.add_argument("--requirements", help="Submit file requirements")
+    subdag.add_argument(
         "--requirements_file", help="File containing submit file requirements"
     )
-    parser_subdag.add_argument(
+    subdag.add_argument(
         "--unique-id", help="Set UniqueId in submitted jobs", dest="unique_id"
     )
-    parser_subdag.add_argument(
+    subdag.add_argument(
         "--test-mode",
         help="Testing mode (only transfers small files)",
         default=False,
@@ -175,37 +95,53 @@ def parse_args():
         dest="test_mode",
     )
 
-    parser_exec = subparsers.add_parser("exec")
-    parser_exec.add_argument("src")
+    exec = subparsers.add_parser("exec")
+    exec.add_argument("src")
 
-    parser_verify_remote = subparsers.add_parser("verify_remote")
-    parser_verify_remote.add_argument("src")
+    verify_remote = subparsers.add_parser("verify_remote")
+    verify_remote.add_argument("src")
 
-    parser_verify = subparsers.add_parser("verify")
+    verify = subparsers.add_parser("verify")
     # SCRIPT POST xfer_{name} {xfer_py} verify {dest_prefix} {dest} {src_file_noslash}.metadata {transfer_manifest}
-    # parser_verify.add_argument("dest_prefix")
-    # parser_verify.add_argument("dest")
-    # parser_verify.add_argument("metadata")
-    # parser_verify.add_argument("metadata_summary")
-    parser_verify.add_argument("--json", dest="json")
-    parser_verify.add_argument("--fileid", dest="fileid")
+    # verify.add_argument("dest_prefix")
+    # verify.add_argument("dest")
+    # verify.add_argument("metadata")
+    # verify.add_argument("metadata_summary")
+    verify.add_argument("--json", dest="json")
+    verify.add_argument("--fileid", dest="fileid")
 
-    parser_analyze = subparsers.add_parser("analyze")
-    parser_analyze.add_argument("transfer_manifest")
+    analyze = subparsers.add_parser("analyze")
+    analyze.add_argument("transfer_manifest")
 
     return parser.parse_args()
 
 
-def generate_file_listing(src, manifest, test_mode=False):
-    with open(manifest, "w") as fp:
-        for root, dirs, fnames in os.walk(src):
-            for fname in fnames:
-                full_fname = os.path.normpath(os.path.join(root, fname))
-                size = os.stat(full_fname).st_size
-                if test_mode and size > 50 * 1024 * 1024:
-                    continue
-                info = {"name": full_fname, "size": size}
-                fp.write("{}\n".format(json.dumps(info)))
+def read_requirements_file(requirements_file):
+    if requirements_file is None:
+        return None
+
+    return Path(requirements_file).read_text().strip()
+
+
+def generate_file_listing(src, manifest_path, test_mode=False):
+    manifest_path = Path(manifest_path)
+    with manifest_path.open(mode="w") as f:
+        for entry in walk(src):
+            size = entry.stat().st_size
+
+            if test_mode and size > 50 * MB:
+                continue
+
+            info = {"name": entry.path, "size": size}
+            f.write(f"{json.dumps(info)}\n")
+
+
+def walk(path):
+    for entry in os.scandir(path):
+        if entry.is_dir():
+            yield from walk(entry.path)
+        elif entry.is_file():
+            yield entry
 
 
 def submit_parent_dag(
@@ -235,8 +171,8 @@ def submit_parent_dag(
                 "arguments": f"generate {source_dir} {'--test-mode' if test_mode else ''}",
                 "should_transfer_files": "yes",
                 "requirements": requirements if requirements is not None else "True",
-                "My.IsTransferJob": "vanilla",
-                "My.UniqueID": f"{unique_id if unique_id is not None else ''}",
+                "My.IsTransferJob": "true",
+                "My.UniqueID": f"{classad.quote(unique_id) if unique_id is not None else ''}",
                 "My.WantFlocking": "true",
                 "keep_claim_idle": "300",
                 "request_disk": "1GB",
@@ -259,8 +195,8 @@ def submit_parent_dag(
             ],
         ),
     ).child_subdag(
-        name="do_work",
-        dag_file=working_dir / "do_work.dag",
+        name="inner",
+        dag_file=working_dir / "inner.dag",
         post=dags.Script(
             executable=THIS_FILE, arguments=["analyze", transfer_manifest_path]
         ),
@@ -269,11 +205,11 @@ def submit_parent_dag(
     if requirements:
         (working_dir / "requirements.txt").write_text(requirements)
 
-    parent_dag_file = dags.write_dag(
-        parent_dag, dag_dir=working_dir, dag_file_name="parent.dag"
+    outer_dag_file = dags.write_dag(
+        parent_dag, dag_dir=working_dir, dag_file_name="outer.dag"
     )
 
-    sub = htcondor.Submit.from_dag(str(parent_dag_file))
+    sub = htcondor.Submit.from_dag(str(outer_dag_file))
 
     with change_dir(working_dir):
         schedd = htcondor.Schedd()
@@ -289,14 +225,17 @@ def change_dir(dir):
     os.chdir(original)
 
 
-def parse_manifest(prefix, manifest, log_name):
+def parse_manifest(prefix, manifest_path, log_name):
+    manifest_path = Path(manifest_path)
     prefix = os.path.normpath(prefix)
     files = {}
-    with open(manifest, "r") as fd:
-        for line in fd.readlines():
+    with manifest_path.open(mode="r") as fd:
+        for line in fd:
             line = line.strip()
+
             if not line or line.startswith("#"):
                 continue
+
             if line.startswith("{"):
                 info = json.loads(line)
                 if "name" not in info:
@@ -336,7 +275,7 @@ def write_subdag(
     source_manifest,
     dest_prefix,
     dest_manifest,
-    transfer_manifest,
+    transfer_manifest_path,
     requirements=None,
     test_mode=False,
     unique_id=None,
@@ -351,25 +290,27 @@ def write_subdag(
         if src_files[fname] != dest_files.get(fname, -1):
             files_to_xfer.add(fname)
 
-    transfer_manifest = os.path.join(dest_prefix, "transfer_manifest.txt")
-    if not os.path.exists(transfer_manifest):
-        try:
-            os.makedirs(dest_prefix)
-        except OSError as oe:
-            if oe.errno != errno.EEXIST:
-                raise
-        fd = os.open(transfer_manifest, os.O_CREAT | os.O_RDONLY)
-        os.close(fd)
+    transfer_manifest_path = Path(os.path.join(dest_prefix, "transfer_manifest.txt"))
+    transfer_manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    transfer_manifest_path.touch(exist_ok=True)
 
+    # TODO: WHAT DOES THIS DO?
+    # seems like it makes sure we don't re-verify files that have already been verified
+    # ... which means we never transfer files that have already been transferred by name
+    # even if they may have changed at the source!
     files_verified = set()
-    with open(transfer_manifest, "r") as fp:
-        for line in fp.readlines():
+    with transfer_manifest_path.open(mode="r") as f:
+        for line in f:
             line = line.strip()
-            if not line or line[0] == "#":
+
+            if not line or line.startswith("#"):
                 continue
-            info = line.strip().split()
+
+            info = line.split()
+
             if info[0] != "TRANSFER_VERIFIED":
                 continue
+
             if info[1] == "{":
                 info = json.loads(" ".join(info[1:]))
                 if "name" not in info or "digest" not in info or "size" not in info:
@@ -378,6 +319,7 @@ def write_subdag(
                 continue
             else:
                 fname, hexdigest, size = info[1:-1]
+
             relative_fname = fname
             files_verified.add(relative_fname)
 
@@ -385,204 +327,224 @@ def write_subdag(
     for fname in src_files:
         if fname in files_to_xfer:
             continue
+
         if fname not in files_verified:
             files_to_verify.add(fname)
 
-    info = os.path.split(sys.argv[0])
-    full_exec_path = os.path.join(os.path.abspath(info[0]), info[1])
+    inner_dag = dags.DAG(
+        max_jobs_by_category={"TRANSFER_JOBS": 1} if test_mode else None
+    )
 
-    with open("xfer_file.sub", "w") as fp:
-        fp.write(
-            XFER_FILE_JOB.format(
-                xfer_py=full_exec_path,
-                requirements=requirements if requirements is not None else "True",
-                unique_id=unique_id if unique_id is not None else "",
-            )
-        )
-    with open("verify_file.sub", "w") as fp:
-        fp.write(
-            VERIFY_FILE_JOB.format(
-                xfer_py=full_exec_path,
-                requirements=requirements if requirements is not None else "True",
-                unique_id=unique_id if unique_id is not None else "",
-            )
-        )
-
-    idx = 0
     dest_dirs = set()
-    jsonidx = 0
-    cur_jsonidx = 0
-    cmd_info = {}
-    with open("do_work.dag", "w") as fp:
-        fp.write(
-            DO_WORK_DAG_HEADER.format("MAXJOBS TRANSFER_JOBS 1" if test_mode else "")
+    cmd_info = []
+    for idx, fname in enumerate(sorted(files_to_xfer)):
+        src_file = os.path.join(source_prefix, fname)
+        src_file_noslash = fname.replace("/", "_SLASH_").replace(" ", "_SPACE_")
+        dest = os.path.join(dest_prefix, fname)
+        dest_dirs.add(os.path.split(dest)[0])
+
+        logging.info("File transfer to perform: %s->%s", src_file, dest)
+
+        cmd_info.append(
+            {
+                "src_file": src_file,
+                "src_file_noslash": src_file_noslash,
+                "dest": dest,
+                "transfer_manifest": str(transfer_manifest_path),
+                "dest_prefix": dest_prefix,
+            }
         )
-        files_to_xfer = list(files_to_xfer)
-        files_to_xfer.sort()
-        for fname in files_to_xfer:
-            idx += 1
-            src_file = os.path.join(source_prefix, fname)
-            src_file_noslash = fname.replace("/", "_")
-            dest = os.path.join(dest_prefix, fname)
-            dest_dirs.add(os.path.split(dest)[0])
 
-            logging.info("File transfer to perform: %s->%s", src_file, dest)
-            cur_jsonidx = idx / 1000
-            if jsonidx != cur_jsonidx:
-                # xfer_commands_{fileidx}.json
-                with open("xfer_commands_{}.json".format(jsonidx), "w") as cmd_fp:
-                    json.dump(cmd_info, cmd_fp)
-                jsonidx = cur_jsonidx
-                cmd_info = {}
-            cmd_info[str(idx)] = {
+    with open("xfer_commands.json", "w") as cmd_fp:
+        json.dump(dict(enumerate(cmd_info)), cmd_fp)
+
+    inner_dag.layer(
+        name="xfer",
+        submit_description=htcondor.Submit(
+            {
+                "universe": "vanilla",
+                "executable": THIS_FILE.as_posix(),
+                "output": "$(src_file_noslash).out",
+                "error": "$(src_file_noslash).err",
+                "log": "xfer_file.log",
+                "arguments": classad.quote("exec '$(src_file)'"),
+                "should_transfer_files": "yes",
+                "transfer_output_files": f"{SANDBOX_FILE_NAME}, metadata",
+                "transfer_output_remaps": classad.quote(
+                    f"{SANDBOX_FILE_NAME} = $(dest); metadata = $(src_file_noslash).metadata"
+                ),
+                "requirements": requirements if requirements is not None else "True",
+                "My.IsTransferJob": "true",
+                "My.UniqueID": f"{classad.quote(unique_id) if unique_id is not None else ''}",
+                "My.WantFlocking": "true",
+                "keep_claim_idle": "300",
+                "request_disk": "1GB",
+            }
+        ),
+        vars=cmd_info,
+        post=dags.Script(
+            executable=THIS_FILE,
+            arguments=["verify", "--json=xfer_commands.json", "--fileid", "$JOB"],
+        ),
+    )
+
+    cmd_info = []
+    for fname in files_to_verify:
+        src_file = os.path.join(source_prefix, fname)
+        src_file_noslash = fname.replace("/", "_SLASH_").replace(" ", "_SPACE_")
+        dest = os.path.join(dest_prefix, fname)
+
+        logging.info("File to verify: %s", src_file)
+
+        cmd_info.append(
+            {
                 "src_file": src_file,
                 "src_file_noslash": src_file_noslash,
                 "dest": dest,
-                "transfer_manifest": transfer_manifest,
+                "transfer_manifest": transfer_manifest_path,
                 "dest_prefix": dest_prefix,
             }
-            fp.write(
-                DO_WORK_DAG_XFER_SNIPPET.format(
-                    name=idx,
-                    fileidx=cur_jsonidx,
-                    xfer_py=full_exec_path,
-                    src_file=src_file,
-                    src_file_noslash=src_file_noslash,
-                    dest=dest,
-                )
-            )
+        )
 
-        with open("xfer_commands_{}.json".format(cur_jsonidx), "w") as cmd_fp:
-            json.dump(cmd_info, cmd_fp)
+    with open("verify_commands.json", "w") as cmd_fp:
+        json.dump(dict(enumerate(cmd_info)), cmd_fp)
 
-        idx = 0
-        jsonidx = 0
-        cur_jsonidx = 0
-        for fname in files_to_verify:
-            idx += 1
-            src_file = os.path.join(source_prefix, fname)
-            src_file_noslash = fname.replace("/", "_")
-            dest = os.path.join(dest_prefix, fname)
-            logging.info("File to verify: %s", src_file)
-            cur_jsonidx = idx / 1000
-            if jsonidx != cur_jsonidx:
-                with open("verify_commands_{}.json".format(jsonidx), "w") as cmd_fp:
-                    json.dump(cmd_info, cmd_fp)
-                jsonidx = cur_jsonidx
-                cmd_info = {}
-            cmd_info[str(idx)] = {
-                "src_file": src_file,
-                "src_file_noslash": src_file_noslash,
-                "dest": dest,
-                "transfer_manifest": transfer_manifest,
-                "dest_prefix": dest_prefix,
+    inner_dag.layer(
+        name="verify",
+        submit_description=htcondor.Submit(
+            {
+                "universe": "vanilla",
+                "executable": THIS_FILE.as_posix(),
+                "output": "$(src_file_noslash).out",
+                "error": "$(src_file_noslash).err",
+                "log": "verify_file.log",
+                "arguments": classad.quote(f"verify_remote '$(src_file)'"),
+                "should_transfer_files": "yes",
+                "transfer_output_files": "metadata",
+                "transfer_output_remaps": classad.quote(
+                    "metadata = $(src_file_noslash).metadata"
+                ),
+                "requirements": requirements if requirements is not None else "True",
+                "My.IsTransferJob": "true",
+                "My.UniqueID": f"{classad.quote(unique_id) if unique_id is not None else ''}",
+                "My.WantFlocking": "true",
+                "keep_claim_idle": "300",
+                "request_disk": "1GB",
             }
-            fp.write(
-                DO_WORK_DAG_VERIFY_SNIPPET.format(
-                    name=idx,
-                    fileidx=cur_jsonidx,
-                    xfer_py=full_exec_path,
-                    src_file=src_file,
-                    src_file_noslash=src_file_noslash,
-                    dest=dest,
-                )
-            )
+        ),
+        vars=cmd_info,
+        post=dags.Script(
+            executable=THIS_FILE,
+            arguments=["verify", "--json=verify_commands.json", "--fileid", "$JOB"],
+        ),
+    )
 
-        with open("verify_commands_{}.json".format(cur_jsonidx), "w") as cmd_fp:
-            json.dump(cmd_info, cmd_fp)
+    dags.write_dag(inner_dag, dag_dir=Path.cwd(), dag_file_name="inner.dag")
 
     for dest_dir in dest_dirs:
-        try:
-            os.makedirs(dest_dir)
-        except OSError as oe:
-            if oe.errno != errno.EEXIST:
-                raise
+        Path(dest_dir).mkdir(exist_ok=True, parents=True)
 
     bytes_to_transfer = sum(src_files[fname] for fname in files_to_xfer)
     bytes_to_verify = sum(src_files[fname] for fname in files_to_verify)
-    with open(transfer_manifest, "a") as fp:
-        fp.write(
-            "SYNC_REQUEST {} files_at_source={} files_to_transfer={} bytes_to_transfer={} files_to_verify={} bytes_to_verify={} timestamp={}\n".format(
-                source_prefix,
-                len(src_files),
-                len(files_to_xfer),
-                bytes_to_transfer,
-                len(files_to_verify),
-                bytes_to_verify,
-                time.time(),
-            )
+    with transfer_manifest_path.open(mode="a") as f:
+        f.write(
+            f"SYNC_REQUEST {source_prefix} files_at_source={len(src_files)} files_to_transfer={len(files_to_xfer)} bytes_to_transfer={bytes_to_transfer} files_to_verify={len(files_to_verify)} bytes_to_verify={bytes_to_verify} timestamp={time.time()}\n"
         )
+
         for fname in files_to_xfer:
             info = {"name": fname, "size": src_files[fname]}
-            fp.write("TRANSFER_REQUEST {}\n".format(json.dumps(info)))
+            f.write("TRANSFER_REQUEST {}\n".format(json.dumps(info)))
         for fname in files_to_verify:
             info = {"name": fname, "size": src_files[fname]}
-            fp.write("VERIFY_REQUEST {}\n".format(json.dumps(info)))
+            f.write("VERIFY_REQUEST {}\n".format(json.dumps(info)))
 
 
-def xfer_exec(src):
+def xfer_exec(src_path):
+    src_path = Path(src_path)
+
     if "_CONDOR_JOB_AD" not in os.environ:
         print("This executable must be run within the HTCondor runtime environment.")
         sys.exit(1)
 
-    logging.info("About to copy %s to file0", src)
+    dst_path = Path(os.environ["_CONDOR_SCRATCH_DIR"]) / SANDBOX_FILE_NAME
 
-    with open(src, mode="rb") as src_fd, open("file0", mode="wb") as dest_fd:
-        file_size = os.fstat(src_fd.fileno()).st_size
-        logging.info("There are %.2fMB to copy", file_size / 1024.0 / 1024.0)
-        last_log = time.time()
-        buf = src_fd.read(1024 * 1024)
-        hash_obj = hashlib.sha1()
+    logging.info("About to copy %s to %s", src_path, dst_path)
+
+    file_size = src_path.stat().st_size
+    logging.info("There are %.2f MB to copy", file_size / MB)
+    last_log = time.time()
+
+    hash_obj = hashlib.sha1()
+
+    with src_path.open(mode="rb") as src, dst_path.open(mode="wb") as dst:
+        buf = src.read(MB)
         byte_count = len(buf)
+
         while len(buf) > 0:
             hash_obj.update(buf)
-            dest_fd.write(buf)
-            buf = src_fd.read(1024 * 1024)
+            dst.write(buf)
+
+            buf = src.read(MB)
+
             now = time.time()
             if now - last_log > 5:
                 logging.info(
-                    "Copied %.2f of %.2fMB; %.1f%% done",
-                    byte_count / 1024.0 / 1024.0,
-                    file_size / 1024.0 / 1024.0,
+                    "Copied %.2f of %.2f MB; %.1f%% done",
+                    byte_count / MB,
+                    file_size / MB,
                     (byte_count / float(file_size)) * 100,
                 )
                 last_log = now
+
             byte_count += len(buf)
 
         logging.info("Copy complete; about to synchronize file to disk")
-        os.fsync(dest_fd.fileno())
+
+        os.fsync(dst.fileno())
+
         logging.info("File synchronized to disk")
 
     logging.info("File metadata: hash=%s, size=%d", hash_obj.hexdigest(), byte_count)
+
     with open("metadata", "w") as metadata_fd:
-        info = {"name": src, "digest": hash_obj.hexdigest(), "size": byte_count}
+        info = {
+            "name": str(src_path),
+            "digest": hash_obj.hexdigest(),
+            "size": byte_count,
+        }
         metadata_fd.write("{}\n".format(json.dumps(info)))
 
 
 def verify_remote(src):
+    src = Path(src)
+
     if "_CONDOR_JOB_AD" not in os.environ:
         print("This executable must be run within the HTCondor runtime environment.")
         sys.exit(1)
 
     logging.info("About to verify %s", src)
 
-    with open(src, mode="rb") as src_fd:
-        file_size = os.fstat(src_fd.fileno()).st_size
-        logging.info("There are %.2fMB to verify", file_size / 1024.0 / 1024.0)
-        last_log = time.time()
-        buf = src_fd.read(1024 * 1024)
-        hash_obj = hashlib.sha1()
+    file_size = src.stat().st_size
+
+    logging.info("There are %.2f MB to verify", file_size / MB)
+    last_log = time.time()
+
+    hash_obj = hashlib.sha1()
+
+    with src.open(mode="rb") as src_fd:
+        buf = src_fd.read(MB)
         byte_count = len(buf)
+
         while len(buf) > 0:
             hash_obj.update(buf)
-            buf = src_fd.read(1024 * 1024)
+            buf = src_fd.read(MB)
             now = time.time()
             if now - last_log > 5:
                 logging.info(
-                    "Copied %.2f of %.2fMB; %.1f%% done",
-                    byte_count / 1024.0 / 1024.0,
-                    file_size / 1024.0 / 1024.0,
-                    (byte_count / float(file_size)) * 100,
+                    "Copied %.2f of %.2f MB; %.1f%% done",
+                    byte_count / MB,
+                    file_size / MB,
+                    (byte_count / file_size) * 100,
                 )
                 last_log = now
             byte_count += len(buf)
@@ -590,62 +552,75 @@ def verify_remote(src):
     logging.info("Checksum computation complete")
 
     logging.info("File metadata: hash=%s, size=%d", hash_obj.hexdigest(), byte_count)
+
     with open("metadata", "w") as metadata_fd:
         info = {"name": src, "digest": hash_obj.hexdigest(), "size": byte_count}
-        metadata_fd.write("{}\n".format(json.dumps(info)))
+        metadata_fd.write(f"{json.dumps(info)}\n")
 
 
-def verify(dest_prefix, dest, metadata, metadata_summary):
-    with open(metadata, "r") as metadata_fd:
-        if os.fstat(metadata_fd.fileno()).st_size > 16384:
-            logging.error("Metadata file is too large")
-            sys.exit(1)
+def verify(dest_prefix, dest, metadata_path, metadata_summary):
+    dest_prefix = Path(dest_prefix)
+    dest = Path(dest)
+    metadata_path = Path(metadata_path)
+    metadata_summary = Path(metadata_summary)
 
-        contents = metadata_fd.read().strip()
+    if metadata_path.stat().st_size > 16384:
+        logging.error("Metadata file is too large")
+        sys.exit(1)
 
-        if not contents:
-            logging.error("Metadata file is empty")
-            sys.exit(1)
+    contents = metadata_path.read_text().strip()
 
-        info = json.loads(contents)
+    if not contents:
+        logging.error("Metadata file is empty")
+        sys.exit(1)
 
-        if any(key not in info for key in {"name", "digest", "size"}):
-            logging.error("Metadata file format incorrect; missing keys")
-            sys.exit(1)
+    info = json.loads(contents)
 
-        src_fname = info["name"]
-        src_hexdigest = info["digest"]
-        src_size = int(info["size"])
+    if any(key not in info for key in {"name", "digest", "size"}):
+        logging.error("Metadata file format incorrect; missing keys")
+        sys.exit(1)
 
-    relative_fname = dest[len(dest_prefix) + 1 :]
+    src_fname = info["name"]
+    src_hexdigest = info["digest"]
+    src_size = int(info["size"])
+
+    relative_fname = dest.relative_to(dest_prefix)
 
     logging.info("About to verify contents of %s", dest)
-    with open(dest, mode="rb") as dest_fd:
-        dest_size = os.fstat(dest_fd.fileno()).st_size
-        if src_size != dest_size:
-            logging.error(
-                "Copied file size (%d bytes) does not match source file size (%d bytes)",
-                dest_size,
-                src_size,
-            )
-            sys.exit(2)
-        logging.info("There are %.2fMB to verify", dest_size / 1024.0 / 1024.0)
-        last_log = time.time()
-        buf = dest_fd.read(1024 * 1024)
-        hash_obj = hashlib.sha1()
+
+    dest_size = dest.stat().st_size
+
+    if src_size != dest_size:
+        logging.error(
+            "Copied file size (%d bytes) does not match source file size (%d bytes)",
+            dest_size,
+            src_size,
+        )
+        sys.exit(2)
+
+    logging.info("There are %.2f MB to verify", dest_size / MB)
+    last_log = time.time()
+
+    hash_obj = hashlib.sha1()
+
+    with dest.open(mode="rb") as dest_fd:
+        buf = dest_fd.read(MB)
         byte_count = len(buf)
+
         while len(buf) > 0:
             hash_obj.update(buf)
-            buf = dest_fd.read(1024 * 1024)
+            buf = dest_fd.read(MB)
+
             now = time.time()
             if now - last_log > 5:
                 logging.info(
-                    "Verified %.2f of %.2fMB; %.1f%% done",
-                    byte_count / 1024.0 / 1024.0,
-                    dest_size / 1024.0 / 1024.0,
-                    (byte_count / float(dest_size)) * 100,
+                    "Verified %.2f of %.2f MB; %.1f%% done",
+                    byte_count / MB,
+                    dest_size / MB,
+                    (byte_count / dest_size) * 100,
                 )
                 last_log = now
+
             byte_count += len(buf)
 
     dest_hexdigest = hash_obj.hexdigest()
@@ -659,45 +634,45 @@ def verify(dest_prefix, dest, metadata, metadata_summary):
             src_fname,
         )
         sys.exit(1)
-    else:
-        logging.info(
-            "File verification successful: Destination (%s) and source (%s) have matching"
-            " SHA1 digest (%s)",
-            dest,
-            src_fname,
-            src_hexdigest,
-        )
 
-    with open(metadata_summary, "a") as md_fd:
+    logging.info(
+        "File verification successful: Destination (%s) and source (%s) have matching"
+        " SHA1 digest (%s)",
+        dest,
+        src_fname,
+        src_hexdigest,
+    )
+
+    with metadata_summary.open(mode="a") as md_fd:
         info = {
-            "name": relative_fname,
+            "name": str(relative_fname),
             "digest": src_hexdigest,
             "size": src_size,
             "timestamp": int(time.time()),
         }
-        md_fd.write("TRANSFER_VERIFIED {}\n".format(json.dumps(info)))
+        md_fd.write(f"TRANSFER_VERIFIED {json.dumps(info)}\n")
         os.fsync(md_fd.fileno())
 
-    os.unlink(metadata)
-    if metadata.endswith(".metadata"):
-        out_file = metadata[:-8] + "out"
-        if os.path.exists(out_file):
-            os.unlink(out_file)
-        err_file = metadata[:-8] + "err"
-        if os.path.exists(err_file):
-            os.unlink(err_file)
+    metadata_path.unlink()
+    if metadata_path.suffix == ".metadata":
+        out_file = metadata_path.with_suffix(".out")
+        if out_file.exists():
+            out_file.unlink()
+        err_file = metadata_path.with_suffix(".err")
+        if err_file.exists():
+            err_file.unlink()
 
 
 def analyze(transfer_manifest):
+    transfer_manifest = Path(transfer_manifest)
+
     sync_request_start = None
-    idx = -1
     sync_request = {"files": {}, "xfer_files": set(), "verified_files": {}}
     dest_dir = os.path.abspath(os.path.split(transfer_manifest)[0])
     sync_count = 0
 
     with open(transfer_manifest, "r") as fp:
-        for line in fp.readlines():
-            idx += 1
+        for idx, line in enumerate(transfer_manifest.open(mode="r")):
             info = line.strip().split()
             # Format: SYNC_REQUEST {} files_at_source={} files_to_transfer={} bytes_to_transfer={} files_to_verify={} bytes_to_verify={} timestamp={}
             if info[0] == "SYNC_REQUEST":
@@ -712,27 +687,21 @@ def analyze(transfer_manifest):
                     if key == "timestamp":
                         continue
                     sync_request[key] = int(val)
-            elif (
-                info[0] == "TRANSFER_REQUEST" or info[0] == "VERIFY_REQUEST"
-            ):  # Format: TRANSFER_REQUEST fname size
+            # Format: TRANSFER_REQUEST fname size
+            elif info[0] == "TRANSFER_REQUEST" or info[0] == "VERIFY_REQUEST":
                 if sync_request_start is None:
                     logging.error(
                         "Transfer request found at line %d before sync started; inconsistent log",
                         idx,
                     )
                     sys.exit(4)
-                if info[1][0] == "{":
-                    local_info = json.loads(" ".join(info[1:]))
-                    size = int(local_info["size"])
-                    fname = local_info["name"]
-                else:
-                    size = int(info[2])
-                    fname = info[1]
+
+                local_info = json.loads(" ".join(info[1:]))
+                size = int(local_info["size"])
+                fname = local_info["name"]
+
                 # File was previously verified.
-                if (
-                    fname in sync_request["verified_files"]
-                    and sync_request["verified_files"][fname] == size
-                ):
+                if sync_request["verified_files"].get(fname, None) == size:
                     continue
                 sync_request["files"][fname] = size
                 if info[0] == "TRANSFER_REQUEST":
@@ -741,27 +710,22 @@ def analyze(transfer_manifest):
                         sync_request["xfer_files"].add(local_info["name"])
                     else:
                         sync_request["xfer_files"].add(info[1])
-            elif (
-                info[0] == "TRANSFER_VERIFIED"
-            ):  # Format: TRANSFER_VERIFIED relative_fname hexdigest size timestamp:
+            # Format: TRANSFER_VERIFIED relative_fname hexdigest size timestamp:
+            elif info[0] == "TRANSFER_VERIFIED":
                 if sync_request_start is None:
                     logging.error(
                         "Transfer verification found at line %d before sync started; inconsistent log",
                         idx,
                     )
                     sys.exit(4)
-                if info[1][0] == "{":
-                    local_info = json.loads(" ".join(info[1:]))
-                    fname = local_info["name"]
-                    size = int(local_info["size"])
-                else:
-                    fname = info[1]
-                    size = int(info[3])
-                if (
-                    fname in sync_request["verified_files"]
-                    and sync_request["verified_files"][fname] == size
-                ):
+
+                local_info = json.loads(" ".join(info[1:]))
+                fname = local_info["name"]
+                size = int(local_info["size"])
+
+                if sync_request["verified_files"].get(fname, None) == size:
                     continue
+
                 if fname not in sync_request["files"]:
                     logging.error("File %s verified but was not requested.", fname)
                     sys.exit(4)
@@ -813,8 +777,10 @@ def analyze(transfer_manifest):
                         "SYNC_DONE but there is work remaining: %s", str(sync_request)
                     )
                     sys.exit(4)
+
                 sync_request_start = None
                 sync_request = {"files": {}, "xfer_files": set(), "verified_files": {}}
+
         if sync_request_start is not None and (
             sync_request["files_to_verify"]
             or sync_request["bytes_to_verify"]
@@ -835,9 +801,10 @@ def analyze(transfer_manifest):
             )
             logging.error("Inconsistent files: {}".format(str(sync_request["files"])))
             sys.exit(4)
+
     if sync_request_start is not None:
-        with open(transfer_manifest, "a") as fp:
-            fp.write("SYNC_DONE {}\n".format(int(time.time())))
+        with transfer_manifest.open(mode="a") as f:
+            f.write(f"SYNC_DONE {int(time.time())}\n")
         print("Synchronization done; verification complete.")
     elif sync_count:
         print("All synchronizations done; verification complete")
@@ -861,24 +828,18 @@ def main():
             if args.cmd == "sync":
                 if args.unique_id:
                     schedd = htcondor.Schedd()
-                    if (
-                        len(
-                            schedd.query(
-                                constraint='UniqueId == "{}" && JobStatus =!= 4'.format(
-                                    args.unique_id
-                                ),
-                                attr_list=[],
-                                limit=1,
-                            )
-                        )
-                        > 0
-                    ):
+                    existing_job = schedd.query(
+                        constraint=f"UniqueId == {classad.quote(args.unique_id)} && JobStatus =!= 4",
+                        attr_list=[],
+                        limit=1,
+                    )
+                    if len(existing_job) > 0:
                         logging.warning(
                             'Jobs already found in queue with UniqueId == "%s", exiting',
                             args.unique_id,
                         )
                         sys.exit()
-                working_dir = args.working_dir if args.working_dir else os.getcwd()
+                working_dir = args.working_dir or os.getcwd()
                 print(
                     f"Will synchronize {args.src} at source to {args.dest} at destination"
                 )
@@ -919,11 +880,12 @@ def main():
             elif args.cmd == "verify":
                 with open(args.json, "r") as fp:
                     cmd_info = json.load(fp)
-                info = cmd_info[args.fileid]
+                # Split the DAG job name to get the cmd_info key
+                info = cmd_info[args.fileid.split(":")[-1]]
                 verify(
                     info["dest_prefix"],
                     info["dest"],
-                    "{}.metadata".format(info["src_file_noslash"]),
+                    f"{info['src_file_noslash']}.metadata",
                     info["transfer_manifest"],
                 )
             elif args.cmd == "verify_remote":

--- a/xfer.py
+++ b/xfer.py
@@ -182,26 +182,19 @@ def parse_manifest(prefix: Path, manifest_path: Path, log_name):
             if not line or line.startswith("#"):
                 continue
 
-            if line.startswith("{"):
-                info = json.loads(line)
-                if "name" not in info:
-                    raise Exception(
-                        "Manifest line missing 'name' key.  Current line: %s" % line
-                    )
-                fname = info["name"]
-                if "size" not in info:
-                    raise Exception(
-                        "Manifest line missing 'size' key.  Current line: %s" % line
-                    )
-                size = int(info["size"])
-            else:
-                info = line.strip().split()
-                if len(info) != 2:
-                    raise Exception(
-                        "Manifest lines must have two columns.  Current line: %s" % line
-                    )
-                fname = info[0]
-                size = int(info[1])
+            info = json.loads(line)
+
+            if "name" not in info:
+                raise Exception(
+                    "Manifest line missing 'name' key.  Current line: %s" % line
+                )
+            fname = info["name"]
+            if "size" not in info:
+                raise Exception(
+                    "Manifest line missing 'size' key.  Current line: %s" % line
+                )
+            size = int(info["size"])
+
             if not fname.startswith(prefix):
                 logging.error(
                     "%s file (%s) does not start with specified prefix", log_name, fname
@@ -649,11 +642,8 @@ def analyze(transfer_manifest: Path):
                 continue
             sync_request["files"][fname] = size
             if info[0] == "TRANSFER_REQUEST":
-                if info[1][0] == "{":
-                    local_info = json.loads(" ".join(info[1:]))
-                    sync_request["xfer_files"].add(local_info["name"])
-                else:
-                    sync_request["xfer_files"].add(info[1])
+                local_info = json.loads(" ".join(info[1:]))
+                sync_request["xfer_files"].add(local_info["name"])
         # Format: TRANSFER_VERIFIED relative_fname hexdigest size timestamp:
         elif info[0] == "TRANSFER_VERIFIED":
             if sync_request_start is None:

--- a/xfer.py
+++ b/xfer.py
@@ -65,7 +65,7 @@ def walk(path: Path) -> Iterator[os.DirEntry]:
 def shared_submit_descriptors(unique_id=None, requirements=None):
     return {
         "executable": THIS_FILE.as_posix(),
-        "My.IsTransferJob": "true",
+        "My.Is_Transfer_Job": "true",
         "My.WantFlocking": "true",
         "keep_claim_idle": "300",
         "request_disk": "1GB",

--- a/xfer.py
+++ b/xfer.py
@@ -70,7 +70,9 @@ def shared_submit_descriptors(unique_id=None, requirements=None):
         "request_disk": "1GB",
         "on_exit_hold": "ExitCode =!= 0",
         "requirements": requirements if requirements is not None else "true",
-        "My.UniqueID": "{}".format(classad.quote(unique_id) if unique_id is not None else ''),
+        "My.UniqueID": "{}".format(
+            classad.quote(unique_id) if unique_id is not None else ""
+        ),
     }
 
 
@@ -141,7 +143,9 @@ def make_outer_dag(
                 "output": "calc_work.out",
                 "error": "calc_work.err",
                 "log": "calc_work.log",
-                "arguments": "generate {} {}".format(source_dir, '--test-mode' if test_mode else ''),
+                "arguments": "generate {} {}".format(
+                    source_dir, "--test-mode" if test_mode else ""
+                ),
                 "should_transfer_files": "yes",
                 **shared_submit_descriptors(unique_id, requirements),
             }
@@ -298,7 +302,15 @@ def write_inner_dag(
     bytes_to_verify = sum(src_files[fname] for fname in files_to_verify)
     with transfer_manifest_path.open(mode="a") as f:
         f.write(
-            "SYNC_REQUEST {} files_at_source={} files_to_transfer={} bytes_to_transfer={} files_to_verify={} bytes_to_verify={} timestamp={}\n".format(source_prefix, len(src_files), len(files_to_xfer), bytes_to_transfer, len(files_to_verify), bytes_to_verify, time.time())
+            "SYNC_REQUEST {} files_at_source={} files_to_transfer={} bytes_to_transfer={} files_to_verify={} bytes_to_verify={} timestamp={}\n".format(
+                source_prefix,
+                len(src_files),
+                len(files_to_xfer),
+                bytes_to_transfer,
+                len(files_to_verify),
+                bytes_to_verify,
+                time.time(),
+            )
         )
 
         for fname in files_to_xfer:
@@ -381,7 +393,9 @@ def make_inner_dag(
                 "should_transfer_files": "yes",
                 "transfer_output_files": "{}, metadata".format(SANDBOX_FILE_NAME),
                 "transfer_output_remaps": classad.quote(
-                    "{} = $(dest); metadata = $(src_file_noslash).metadata".format(SANDBOX_FILE_NAME)
+                    "{} = $(dest); metadata = $(src_file_noslash).metadata".format(
+                        SANDBOX_FILE_NAME
+                    )
                 ),
                 **shared_submit_descriptors(unique_id, requirements),
             }
@@ -866,7 +880,9 @@ def main():
         if args.unique_id:
             schedd = htcondor.Schedd()
             existing_job = schedd.query(
-                constraint="UniqueId == {} && JobStatus =!= 4".format(classad.quote(args.unique_id)),
+                constraint="UniqueId == {} && JobStatus =!= 4".format(
+                    classad.quote(args.unique_id)
+                ),
                 attr_list=[],
                 limit=1,
             )
@@ -876,7 +892,11 @@ def main():
                     args.unique_id,
                 )
                 sys.exit()
-        print("Will synchronize {} at source to {} at destination".format(args.src, args.dest))
+        print(
+            "Will synchronize {} at source to {} at destination".format(
+                args.src, args.dest
+            )
+        )
         cluster_id = submit_outer_dag(
             args.working_dir,
             args.src,
@@ -917,7 +937,7 @@ def main():
         verify(
             Path(info["dest_prefix"]),
             Path(info["dest"]),
-            Path("{}.metadata".format(info['src_file_noslash'])),
+            Path("{}.metadata".format(info["src_file_noslash"])),
             Path(info["transfer_manifest"]),
         )
     elif args.cmd == "verify_remote":

--- a/xfer.py
+++ b/xfer.py
@@ -131,13 +131,13 @@ class ManifestEntry(metaclass=abc.ABCMeta):
     def write_entry_to(self, file):
         file.write(self.to_entry())
 
-    @abc.abstractmethod
     @property
+    @abc.abstractmethod
     def keys(self) -> Tuple[str, ...]:
         raise NotImplementedError
 
-    @abc.abstractmethod
     @property
+    @abc.abstractmethod
     def type(self) -> ManifestEntryType:
         raise NotImplementedError
 

--- a/xfer.py
+++ b/xfer.py
@@ -29,7 +29,7 @@ TB = 2 ** 40
 METADATA_FILE_SIZE_LIMIT = 16 * KB
 SANDBOX_FILE_NAME = "file-for-xfer"
 
-THIS_FILE = Path(__file__).absolute()
+THIS_FILE = Path(__file__).resolve()
 
 K = TypeVar("K")
 V = TypeVar("V")


### PR DESCRIPTION
This PR depends on #13 

This PR implements a "push" mode, parallel to the existing "pull" mode.

The CLI entrypoint format is slightly different: `xfer.py sync [pull|push] local_dir remote_dir`. Pull moves files from remote to local; push moves files from local to remote. Other than that, there are no external API changes.

It will require a manifest rewrite, since the `SYNC_REQUEST` entry includes a new field saying whether that sync was a push or a pull. All existing syncs should, of course, be marked as pulls.

```
SYNC_REQUEST {"direction": "push", "remote_prefix": "/home/jtk/projects/htcondor_file_transfer/remote", "files_at_source": 4, "files_to_transfer": 4, "bytes_to_transfer": 10289741842, "files_to_verify": 0, "bytes_to_verify": 0, "timestamp": 1596835687.7967567}
```

Marked as draft because I want to do some cleanup and poke at the verification code. Given that I've done a lot of refactoring over the last few days, this might also be a good point to stop and write some documentation.