### PR TITLE
Updates for v8.9.9

### DIFF
--- a/xfer.py
+++ b/xfer.py
@@ -44,7 +44,7 @@ VERIFY_COMMANDS_FILE_NAME = "verify_commands.json"
 
 OUTER_DAG_NAME = "outer.dag"
 INNER_DAG_NAME = "inner.dag"
-DAG_ARGS = {"force": 1}
+DAG_ARGS = {"force": True}
 
 THIS_FILE = Path(__file__).resolve()
 


### PR DESCRIPTION
In the HTCondor Python bindings, somewhere between 8.9.8 and 8.9.9 (perhaps [this commit](https://github.com/htcondor/htcondor/commit/03a491596193c009bf51244fbc247295c9b2034c)?), `Submit.from_dag()` went from requiring `"force"` in the options dictionary to be the int `1` to requiring it be the bool `True`.