### PR TITLE
Limit the length of a "flattened path" to <= 80 characters

### DIFF
--- a/xfer.py
+++ b/xfer.py
@@ -764,8 +764,13 @@ def write_cmd_info(cmd_info: T_CMD_INFO, path: Path) -> None:
 
 
 def flatten_path(path: Path) -> str:
-    # TODO: this doesn't make sense on Windows
-    return str(path).replace("/", "_SLASH_").replace(" ", "_SPACE_")
+    # Generate a unique file name (technically, unique up to hash
+    # collisions) that will sort last alphabetically in the working
+    # directory.
+
+    digest = hashlib.sha1(bytes(str(path), "utf-8")).hexdigest()
+    suffix = path.suffix[:10]
+    return f"zz_transferred_file_{digest}{suffix}"
 
 
 def path_values_to_strings(mapping):

--- a/xfer.py
+++ b/xfer.py
@@ -770,7 +770,7 @@ def flatten_path(path: Path) -> str:
 
     digest = hashlib.sha1(bytes(str(path), "utf-8")).hexdigest()
     suffix = path.suffix[:10]
-    return f"zz_transferred_file_{digest}{suffix}"
+    return "zz_transferred_file_{}{}".format(digest, suffix)
 
 
 def path_values_to_strings(mapping):


### PR DESCRIPTION
The main idea is to use a SHA-1 hash of the path in the archive rather than simply replacing `/` with `_SLASH_`.

Using `zz_transferred_file` and keeping (part of) the original suffix is intended to keep the transfer utility's working directory somewhat readable and organized.